### PR TITLE
Disk statistics collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+language: go
+go:
+- 1.4.2
+- 1.5
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-disk
+  matrix:
+    - TEST=unit
+before_install:
+- go get github.com/tools/godep
+- go get github.com/intelsdi-x/snap
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# snap collector plugin - disk
+
+1. [Contributing Code](#contributing-code)
+2. [Contributing Examples](#contributing-examples)
+3. [Contribute Elsewhere](#contribute-elsewhere)
+4. [Thank You](#thank-you)
+
+
+This repository is primarily **community supported**. We both appreciate and need your contribution to keep it stable.
+Thank you for being part of the community! We love you for it.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/intelsdi-x/snap-plugin-collector-disk/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`  
+	```
+	$ git clone https://github.com/<yourGithubID>/<project>.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request. A few topics we always want more examples of:
+
+* Reading metrics from NIC's registry dump.
+* Unification of metrics' names if discrepancies between vendors exist.
+
+Have you written a blog post about how you use $PROJECT? Send it to us!
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,6 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-disk",
+	"GoVersion": "go1.4.2",
+	"Deps": [
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,308 @@
-# snap-plugin-collector-disk
+# snap collector plugin - disk
+
+This plugin gather disk statistics from /proc/diskstats (Linux 2.6 or higher) or /proc/partitions (Linux 2.4.
+															
+The plugin is used in the [snap framework] (http://github.com/intelsdi-x/snap).				
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](#configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  * [Roadmap](#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Acknowledgements](#acknowledgements)
+
+## Getting Started
+
+### System Requirements
+
+- Linux system
+
+### Installation
+
+#### To build the plugin binary:
+
+Fork https://github.com/intelsdi-x/snap-plugin-collector-disk  
+Clone repo into `$GOPATH/src/github.com/intelsdi-x/`:
+
+```
+$ git clone https://github.com/<yourGithubID>/snap-plugin-collector-disk.git
+```
+
+Build the snap iostat plugin by running make within the cloned repo:
+```
+$ make
+```
+This builds the plugin in `/build/rootfs/`
+
+### Configuration and Usage
+
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+
+## Documentation
+
+### Collected Metrics
+This plugin has the ability to gather the following metrics:
+                                                                                                
+Metric namespace prefix is `/intel/linux/disk/<disk_device>/`																					where '<disk_device>'' expands to sda, sda1, sdb, sdb1 and so on.
+
+Namespace | Description 
+------------ | -------------
+merged_read | The number of read operations per second that could be merged with already queued operations.
+merged_write | The number of write operations per second that could be merged with already queued operations.
+octets_read | The number of octets (bytes) read per second.
+octets_write | The number of octets (bytes) written per second.
+ops_read | The number of read operations per second.
+ops_write | The number of write operations per second.
+time_read | The average time for a read operation to complete in the last interval.
+time_write | the average time for a write operation to complete in the last interval.
+
+                                                                          
+Data type of all above metrics is float64.
+
+By default metrics are gathered once per second.
+
+### Examples
+
+Example of running snap disk collector and writing data to file.
+
+Run the snap daemon:
+```
+$ snapd -l 1 -t 0
+```
+
+Load disk plugin for collecting:
+```
+$ snapctl plugin load $SNAP_CEPH_PLUGIN_DIR/build/rootfs/snap-plugin-collector-disk
+Plugin loaded
+Name: disk
+Version: 1
+Type: collector
+Signed: false
+Loaded Time: Wed, 23 Dec 2015 11:14:37 EST
+```
+See available metrics for all ceph-daemon in cluster:
+```
+$ snapctl metric list
+```
+
+Or see available metrics only for specific disk:
+```
+$ snapctl metric list | grep sda
+```
+
+Load file plugin for publishing:
+```
+$ snapctl plugin load $SNAP_DIR/build/plugin/snap-publisher-file
+Plugin loaded
+Name: file
+Version: 3
+Type: publisher
+Signed: false
+Loaded Time: Wed, 23 Dec 2015 11:15:02 EST
+```
+
+Create a task JSON file (exemplary file in examples/tasks/diskstats-file.json):  
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+		"/intel/linux/disk/sda/ops_read": {},
+                "/intel/linux/disk/sda/ops_write": {},
+                "/intel/linux/disk/sda/merged_read": {},
+                "/intel/linux/disk/sda/merged_write": {},
+                "/intel/linux/disk/sda/octets_read": {},
+                "/intel/linux/disk/sda/octets_write": {},
+                "/intel/linux/disk/sda/io_time": {},
+                "/intel/linux/disk/sda/time_read": {},
+                "/intel/linux/disk/sda/time_write": {},
+                "/intel/linux/disk/sda/weighted_io_time": {},
+                "/intel/linux/disk/sda/pending_ops": {},
+				
+                "/intel/linux/disk/sda1/ops_read": {},
+                "/intel/linux/disk/sda1/ops_write": {},
+                "/intel/linux/disk/sda1/merged_read": {},
+                "/intel/linux/disk/sda1/merged_write": {},
+                "/intel/linux/disk/sda1/octets_read": {},
+                "/intel/linux/disk/sda1/octets_write": {},
+                "/intel/linux/disk/sda1/io_time": {},
+                "/intel/linux/disk/sda1/time_read": {},
+                "/intel/linux/disk/sda1/time_write": {},
+                "/intel/linux/disk/sda1/weighted_io_time": {},
+                "/intel/linux/disk/sda1/pending_ops": {},
+				
+                "/intel/linux/disk/sdb/ops_read": {},
+                "/intel/linux/disk/sdb/ops_write": {},
+                "/intel/linux/disk/sdb/merged_read": {},
+                "/intel/linux/disk/sdb/merged_write": {},
+                "/intel/linux/disk/sdb/octets_read": {},
+                "/intel/linux/disk/sdb/octets_write": {},
+                "/intel/linux/disk/sdb/io_time": {},
+                "/intel/linux/disk/sdb/time_read": {},
+                "/intel/linux/disk/sdb/time_write": {},
+                "/intel/linux/disk/sdb/weighted_io_time": {},
+                "/intel/linux/disk/sdb/pending_ops": {},
+				
+		"/intel/linux/disk/sdb1/ops_read": {},
+                "/intel/linux/disk/sdb1/ops_write": {},
+                "/intel/linux/disk/sdb1/merged_read": {},
+                "/intel/linux/disk/sdb1/merged_write": {},
+                "/intel/linux/disk/sdb1/octets_read": {},
+                "/intel/linux/disk/sdb1/octets_write": {},
+                "/intel/linux/disk/sdb1/io_time": {},
+                "/intel/linux/disk/sdb1/time_read": {},
+                "/intel/linux/disk/sdb1/time_write": {},
+                "/intel/linux/disk/sdb1/weighted_io_time": {},
+                "/intel/linux/disk/sdb1/pending_ops": {},
+				
+		"/intel/linux/disk/sdb2/ops_read": {},
+                "/intel/linux/disk/sdb2/ops_write": {},
+                "/intel/linux/disk/sdb2/merged_read": {},
+                "/intel/linux/disk/sdb2/merged_write": {},
+                "/intel/linux/disk/sdb2/octets_read": {},
+                "/intel/linux/disk/sdb2/octets_write": {},
+                "/intel/linux/disk/sdb2/io_time": {},
+                "/intel/linux/disk/sdb2/time_read": {},
+                "/intel/linux/disk/sdb2/time_write": {},
+                "/intel/linux/disk/sdb2/weighted_io_time": {},
+                "/intel/linux/disk/sdb2/pending_ops": {}								
+            },
+            "config": {
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "plugin_version": 3,
+                    "config": {
+                        "file": "/tmp/published_diskstats"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+Create a task:
+```
+$ snapctl task create -t $SNAP_CEPH_PLUGIN_DIR/examples/tasks/diskstats-file.json
+Using task manifest to create task
+Task created
+ID: 480323af-15b0-4af8-a526-eb2ca6d8ae67
+Name: Task-480323af-15b0-4af8-a526-eb2ca6d8ae67
+State: Running
+```
+
+See sample output from `snapctl task watch <task_id>`
+
+```
+$ snapctl task watch 480323af-15b0-4af8-a526-eb2ca6d8ae67																									
+Watching Task (480323af-15b0-4af8-a526-eb2ca6d8ae67):
+NAMESPACE                                        DATA                            TIMESTAMP                                       SOURCE
+/intel/linux/disk/sda/io_time                    0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/merged_read                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/merged_write               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/octets_read                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/octets_write               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/ops_read                   0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/ops_write                  0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/pending_ops                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/time_read                  0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/time_write                 0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda/weighted_io_time           0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/io_time                   0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/merged_read               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/merged_write              0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/octets_read               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/octets_write              0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/ops_read                  0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/ops_write                 0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/pending_ops               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/time_read                 0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/time_write                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sda1/weighted_io_time          0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/io_time                    285.24017494599997              2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/merged_read                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/merged_write               155.4955120365347               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/octets_read                4.799664198069947e+06           2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/octets_write               2.0893468155700576e+08          2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/ops_read                   0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/ops_write                  338.722707748375                2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/pending_ops                0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/time_read                  4.300686205                     2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/time_write                 121.47803869131272              2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb/weighted_io_time           33117.57281195954               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/io_time                   285.24017494599997              2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/merged_read               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/merged_write              155.4955120365347               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/octets_read               4.799664198069947e+06           2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/octets_write              2.0617126235076627e+08          2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/ops_read                  0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/ops_write                 338.722707748375                2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/pending_ops               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/time_read                 4.300686205                     2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/time_write                119.13865467618942              2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb1/weighted_io_time          33117.57281195954               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/io_time                   0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/merged_read               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/merged_write              0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/octets_read               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/octets_write              2.763419206239478e+06           2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/ops_read                  0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/ops_write                 0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/pending_ops               0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/time_read                 0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/time_write                4.503690537128046               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+/intel/linux/disk/sdb2/weighted_io_time          0                               2015-12-23 11:18:09.224143712 -0500 EST         gklab-108-166
+```
+(Keys `ctrl+c` terminate task watcher)
+
+
+These data are published to file and stored there (in this example in /tmp/published_ceph).
+
+Stop task:
+```
+$ snapctl task stop 480323af-15b0-4af8-a526-eb2ca6d8ae67
+Task stopped:
+ID: 480323af-15b0-4af8-a526-eb2ca6d8ae67
+```
+
+### Roadmap
+
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release.
+
+If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-disk/issues).
+
+## Community Support
+This repository is one of **many** plugins in the **Snap Framework**: a powerful telemetry agent framework. To reach out on other use cases, visit:
+
+* [Snap Gitter channel] (https://gitter.im/intelsdi-x/snap)
+
+The full project is at http://github.com:intelsdi-x/snap.
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+Snap, along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+List authors, co-authors and anyone you'd like to mention
+
+* Author: 	[Izabella Raulin](https://github.com/IzabellaRaulin)
+
+**Thank you!** Your contribution is incredibly important to us.

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -1,0 +1,380 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2015 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+)
+
+const (
+	// Name of plugin
+	Name = "disk"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+
+	nsVendor = "intel"
+	nsClass  = "linux"
+	nsType   = "disk"
+
+	uintMax = ^uint64(0)
+)
+
+const (
+	// name of available metrics
+	nOpsRead        = "ops_read"
+	nOctetsRead     = "octets_read"
+	nOpsWrite       = "ops_write"
+	nOctetsWrite    = "octets_write"
+	nMergedRead     = "merged_read"
+	nTimeRead       = "time_read"
+	nMergedWrite    = "merged_write"
+	nTimeWrite      = "time_write"
+	nPendingOps     = "pending_ops"
+	nIoTime         = "io_time"
+	nWeightedIoTime = "weighted_io_time"
+)
+
+var (
+	// Disk statistics source for kernel 2.6+
+	srcFile = "/proc/diskstats"
+
+	// Source for older kernel versions
+	srcFileOldVer = "/proc/partitions"
+)
+
+// DiskCollector holds disk statistics
+type DiskCollector struct {
+	data     diskStats
+	dataPrev diskStats          // previous data, to calculate derivatives
+	output   map[string]float64 // contains exposed metrics and their value (calculated based on data & dataPrev)
+	first    bool               // is true for first collecting (do not calculate derivatives), after that set false
+}
+
+type diskStats struct {
+	stats     map[string]uint64
+	timestamp time.Time
+}
+
+type diffStats struct {
+	diffWriteTime uint64
+	diffReadTime  uint64
+	diffWriteOps  uint64
+	diffReadOps   uint64
+}
+
+// prefix in metric namespace
+var prefix = []string{nsVendor, nsClass, nsType}
+
+// New returns snap-plugin-collector-disk instance
+func New() (*DiskCollector, error) {
+	dc := &DiskCollector{data: diskStats{stats: map[string]uint64{}, timestamp: time.Now()},
+		dataPrev: diskStats{stats: map[string]uint64{}, timestamp: time.Now()},
+		output:   map[string]float64{},
+		first:    true}
+	return dc, nil
+}
+
+// GetConfigPolicy returns a ConfigPolicy
+func (dc *DiskCollector) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	return cpolicy.New(), nil
+}
+
+// GetMetricTypes returns list of exposed disk stats metrics
+func (dc *DiskCollector) GetMetricTypes(_ plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	mts := []plugin.PluginMetricType{}
+
+	if err := dc.getDiskStats(); err != nil {
+		return nil, err
+	}
+	for stat := range dc.data.stats {
+		metric := plugin.PluginMetricType{Namespace_: createNamespace(stat)}
+		mts = append(mts, metric)
+	}
+	return mts, nil
+}
+
+// CollectMetrics retrieves disk stats values for given metrics
+func (dc *DiskCollector) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	metrics := []plugin.PluginMetricType{}
+	hostname, _ := os.Hostname()
+
+	first := dc.first // true if collecting for the first time
+	if first {
+		dc.first = false
+	}
+
+	// for first collecting skip stash previous data
+	if !first {
+		// stash disk data (dst, src)
+		stashData(&dc.dataPrev, &dc.data)
+	}
+
+	// get presence disk stats
+	if err := dc.getDiskStats(); err != nil {
+		return nil, err
+	}
+
+	//  for first collecting skip derivatives calculation
+	if !first {
+		// calculate derivatives based on data (presence) and previous one; results stored in dc.output
+		if err := dc.calcDerivatives(); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, m := range mts {
+		if v, ok := dc.output[parseNamespace(m.Namespace())]; ok {
+			metric := plugin.PluginMetricType{
+				Namespace_: m.Namespace(),
+				Data_:      v,
+				Source_:    hostname,
+				Timestamp_: dc.data.timestamp,
+			}
+			metrics = append(metrics, metric)
+		}
+	}
+
+	return metrics, nil
+}
+
+// getDiskStats gets disk stats from file (/proc/{diskstats|partitions}) and stores them in the DiskCollector structure
+func (dc *DiskCollector) getDiskStats() error {
+
+	var scanner *bufio.Scanner
+	fieldshift := 0
+
+	//map disk statistics keys (names) to scanned fields
+	data := make(map[string]string)
+
+	fh, err := os.Open(srcFile)
+	defer fh.Close()
+
+	if err == nil {
+		scanner = bufio.NewScanner(fh)
+	} else {
+		// unable to open /proc/diskstats, try to open /proc/partitions
+		/* Kernel 2.4, Partition */
+		fh2, err2 := os.Open(srcFileOldVer)
+		defer fh2.Close()
+
+		if err2 != nil {
+			return fmt.Errorf("Error open /proc/{diskstats|partitions}, errors = %s; %s", err, err2)
+		}
+
+		/* Kernel is 2.4.* */
+		fieldshift = 1
+		scanner = bufio.NewScanner(fh2)
+	}
+
+	dc.data.timestamp = time.Now()
+
+	// scan file content
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		numfields := len(fields)
+
+		if numfields != 14+fieldshift && numfields != 7 {
+			// unknown entry, ignore it
+			continue
+		}
+
+		// get minor device number
+		minor, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			// invalid format of file
+			return err
+		}
+
+		diskName := fields[2+fieldshift]
+
+		if numfields == 7 {
+			/* Kernel < 2.6, proc/partitions */
+			data[nOpsRead] = fields[3]
+			data[nOctetsRead] = fields[4] // read sectors
+			data[nOpsWrite] = fields[5]
+			data[nOctetsWrite] = fields[6] // write sectors
+
+		} else if numfields == (14 + fieldshift) {
+			/* Kernel 2.6 or higher, proc/diskstats */
+			data[nOpsRead] = fields[3+fieldshift]
+			data[nOctetsRead] = fields[5+fieldshift]
+			data[nOpsWrite] = fields[7+fieldshift]
+			data[nOctetsWrite] = fields[9+fieldshift]
+
+			if fieldshift == 0 || minor == 0 {
+				// extended statistics
+				data[nMergedRead] = fields[4+fieldshift]
+				data[nTimeRead] = fields[6+fieldshift]
+				data[nMergedWrite] = fields[8+fieldshift]
+				data[nTimeWrite] = fields[10+fieldshift]
+				data[nPendingOps] = fields[11+fieldshift] // ops currently in progress
+				data[nIoTime] = fields[12+fieldshift]
+				data[nWeightedIoTime] = fields[13+fieldshift]
+			} // end of extended stats
+
+		}
+
+		for key, val := range data {
+			// parse disk stats value
+			if value, err := strconv.ParseUint(val, 10, 64); err == nil {
+				dc.data.stats[diskName+"/"+key] = value
+			} else {
+				// parse failure
+				return fmt.Errorf("Error %+v, cannot convert value of `%+v` equals %+v to uint64", err, diskName+"/"+key, val)
+			}
+		}
+	} // end of scanner.Scan()
+
+	return nil
+}
+
+// calcDerivatives calculates derivatives of metrics values and stored them in DiskCollector structure as a 'output'
+func (dc *DiskCollector) calcDerivatives() error {
+	interval := dc.data.timestamp.Sub(dc.dataPrev.timestamp).Seconds()
+
+	if interval <= 0 {
+		return errors.New("Invalid interval value")
+	}
+
+	if len(dc.data.stats) == 0 || len(dc.dataPrev.stats) == 0 {
+		return errors.New("No data for calculation")
+	}
+
+	var diffVal uint64
+
+	// (for each disk) keep values of the stats differences which are needed to calculate avg disk time
+	avgDiskTime := make(map[string]*diffStats)
+
+	for key, val := range dc.data.stats {
+
+		if strings.HasSuffix(key, nPendingOps) {
+			// for 'pending_ops' output value is simply stored as-is
+			dc.output[key] = float64(val)
+			continue
+		}
+
+		/** Calculate the change of the value in interval time **/
+
+		valPrev := dc.dataPrev.stats[key]
+
+		// if the counter wraps around
+		if val < valPrev {
+			diffVal = 1 + val + (uintMax - valPrev)
+		} else {
+			diffVal = val - valPrev
+		}
+
+		deriveVal := float64(diffVal) / interval
+
+		disk, nMetric := parseMetricKey(key)
+
+		if _, exists := avgDiskTime[disk]; exists == false {
+			avgDiskTime[disk] = new(diffStats)
+		}
+
+		// switch special case for some metrics based on the last part of metric name
+		switch nMetric {
+		// switch case based on the last part of metric name
+		case nOctetsWrite:
+			dc.output[key] = 512 * deriveVal
+
+		case nOctetsRead:
+			dc.output[key] = 512 * deriveVal
+
+		case nTimeWrite:
+			avgDiskTime[disk].diffWriteTime = diffVal
+
+		case nTimeRead:
+			avgDiskTime[disk].diffReadTime = diffVal
+
+		case nOpsRead:
+			avgDiskTime[disk].diffReadOps = diffVal
+			dc.output[key] = deriveVal
+
+		case nOpsWrite:
+			avgDiskTime[disk].diffWriteOps = diffVal
+			dc.output[key] = deriveVal
+
+		default:
+			dc.output[key] = deriveVal
+		}
+	}
+
+	// calculate disk time
+	for disk, values := range avgDiskTime {
+		dc.output[disk+"/"+nTimeRead] = calcTimeIncrement(values.diffReadTime, values.diffReadOps, interval)
+		dc.output[disk+"/"+nTimeWrite] = calcTimeIncrement(values.diffWriteTime, values.diffWriteOps, interval)
+	}
+
+	return nil
+}
+
+// calcTimeIncrement returns average time of operation based on
+func calcTimeIncrement(deltaTime uint64, deltaOps uint64, interval float64) float64 {
+	if deltaOps == 0 {
+		//not divide by zero
+		return 0
+	}
+	avgTime := float64(deltaTime) / float64(deltaOps)
+	avgTimeIncr := interval * avgTime
+
+	// add 0.5 as it's done in collectd:disk
+	return avgTimeIncr + .5
+}
+
+// stashData copies DiskStats struct variables items with teir values from 'src' to 'dst'
+func stashData(dst *diskStats, src *diskStats) {
+	dst.timestamp = src.timestamp
+
+	// copy map, deep copy is needed
+	for key, value := range src.stats {
+		dst.stats[key] = value
+	}
+}
+
+// createNamespace returns namespace slice of strings composed from: vendor, class, type and components of metric name
+func createNamespace(name string) []string {
+	return append(prefix, strings.Split(name, "/")...)
+}
+
+// parseNamespace performs reverse operation to createNamespace, extracts metric key from namespace
+func parseNamespace(ns []string) string {
+	// skip prefix in namespace
+	metric := ns[len(prefix):]
+	return strings.Join(metric, "/")
+}
+
+// parseMetricKey extracts information about disk and metric name from metric key (exemplary metric key is `sda/time_write`)
+func parseMetricKey(k string) (disk, metric string) {
+	result := strings.Split(k, "/")
+	if len(result) < 2 {
+		// invalid key format, return empty strings
+		return
+	}
+	return result[0], result[1]
+}

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -1,0 +1,313 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2015 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"os"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	invalidValue = iota
+	invalidEntry = iota
+	invalidMinor = iota
+)
+
+var (
+	mockMts = []plugin.PluginMetricType{
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda", "ops_read"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda", "ops_write"},
+		},
+
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda", "octets_read"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda", "octets_write"},
+		},
+
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda1", "ops_read"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda1", "ops_write"},
+		},
+
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda1", "octets_read"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "linux", "disk", "test_sda1", "octets_write"},
+		},
+	}
+
+	srcMockFile       = "/tmp/diskstats_mock"
+	srcMockFileNext   = "/tmp/diskstats_mock_next"
+	srcMockFileOldVer = "/tmp/partitions_mock"
+	srcMockFileInv    = "/tmp/invalid_mock"
+)
+
+func TestGetConfigPolicy(t *testing.T) {
+	Convey("normal case", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+		So(func() { diskPlugin.GetConfigPolicy() }, ShouldNotPanic)
+		_, err = diskPlugin.GetConfigPolicy()
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetMetricTypes(t *testing.T) {
+	srcFile = srcMockFile
+	srcFileOldVer = srcMockFileOldVer
+	var cfg plugin.PluginConfigType
+
+	createMockFiles()
+
+	Convey("source file available, kernel 2.6+", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		So(func() { diskPlugin.GetMetricTypes(cfg) }, ShouldNotPanic)
+		results, err := diskPlugin.GetMetricTypes(cfg)
+
+		So(err, ShouldBeNil)
+		So(results, ShouldNotBeEmpty)
+		// 8 devices/partitions (sda, sda1, sda2, sda3, sdb, sdb1, sdb2) and for each 11 extended stats gives 88 metrics
+		So(len(results), ShouldEqual, 88)
+
+	})
+
+	Convey("source file available, kernel older than 2.6", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		os.Remove(srcFile) // remove srcFile for kernel 2.6+
+		results, err := diskPlugin.GetMetricTypes(cfg)
+
+		So(err, ShouldBeNil)
+		So(results, ShouldNotBeEmpty)
+		// 8 devices/partitions (sda, sda1, sda2, sda3, sdb, sdb1, sdb2) and for each 4 stats gives 32 metrics
+		So(len(results), ShouldEqual, 32)
+	})
+
+	Convey("source files not available", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		deleteMockFiles()
+		results, err := diskPlugin.GetMetricTypes(cfg)
+		So(err, ShouldNotBeNil)
+		So(results, ShouldBeNil)
+	})
+
+	Convey("invalid syntax of source file", t, func() {
+		srcFile = srcMockFileInv
+
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		Convey("invalid value, cannot convert to uint64", func() {
+			createInvalidMockFile(invalidValue)
+			results, err := diskPlugin.GetMetricTypes(cfg)
+			So(err, ShouldNotBeNil)
+			So(results, ShouldBeNil)
+		})
+
+		Convey("unknown entry, ignore it", func() {
+			createInvalidMockFile(invalidEntry)
+			results, err := diskPlugin.GetMetricTypes(cfg)
+
+			So(results, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("invalid device minor number", func() {
+			createInvalidMockFile(invalidMinor)
+			results, err := diskPlugin.GetMetricTypes(cfg)
+			So(err, ShouldNotBeNil)
+			So(results, ShouldBeNil)
+		})
+	})
+}
+
+func TestCollectMetrics(t *testing.T) {
+	srcFile = srcMockFile
+	srcFileOldVer = srcMockFileOldVer
+	createMockFiles()
+
+	Convey("source file available", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		results, err := diskPlugin.CollectMetrics(mockMts)
+		Convey("first data collecting", func() {
+			So(err, ShouldBeNil)
+			So(results, ShouldBeEmpty)
+		})
+
+		Convey("next data collecting", func() {
+
+			Convey("no data change", func() {
+				results, err := diskPlugin.CollectMetrics(mockMts)
+				So(err, ShouldBeNil)
+				So(results, ShouldNotBeEmpty)
+				So(len(results), ShouldEqual, len(mockMts))
+				for _, r := range results {
+					So(r.Data(), ShouldEqual, 0)
+				}
+			})
+
+			Convey("change values of data", func() {
+				srcFile = srcMockFileNext
+				results, err := diskPlugin.CollectMetrics(mockMts)
+				So(err, ShouldBeNil)
+				So(results, ShouldNotBeEmpty)
+				So(len(results), ShouldEqual, len(mockMts))
+
+				for _, r := range results {
+					So(r.Data(), ShouldNotEqual, 0)
+				}
+			})
+		})
+	})
+
+	Convey("invalid calculation of derivatives", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		diskPlugin.first = false
+		Convey("no previous data", func() {
+			results, err := diskPlugin.CollectMetrics(mockMts)
+
+			So(err, ShouldNotBeNil)
+			So(results, ShouldBeNil)
+		})
+
+	})
+
+	deleteMockFiles()
+	Convey("source files not available", t, func() {
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		results, err := diskPlugin.CollectMetrics(mockMts)
+		So(err, ShouldNotBeNil)
+		So(results, ShouldBeNil)
+	})
+
+}
+
+func createMockFiles() {
+	deleteMockFiles()
+	// 	mocked content of srcMockFile (kernel 2.6+)
+	srcMockFileCont := []byte(`    8       0 test_sda 1546 2303 12644 114 0 0 0 0 0 68 114
+								   8       1 test_sda1 333 8 2728 28 0 0 0 0 0 28 28
+								   8       2 test_sda2 330 2264 2604 20 0 0 0 0 0 20 20
+								   8       3 test_sda3 328 0 2624 29 0 0 0 0 0 29 29
+								   8       4 test_sda4 325 0 2600 25 0 0 0 0 0 25 25
+								   8      16 test_sdb 197890 10231 6405324 76885 11345881 15065577 592035256 7904803 0 1237705 7973111
+								   8      17 test_sdb1 79104 984 3301786 23605 8288060 13802816 533998912 6032422 0 1162267 6047374
+								   8      18 test_sdb2 118610 9212 3101850 53254 2979961 1262761 58036344 1859439 0 106811 1918865`)
+
+	// 	mocked content of srcMockFileNext (kernel 2.6+)	in next collection
+	srcMockFileNextCont := []byte(`8       0 test_sda 1541 2304 12645 115 1 1 1 1 1 69 115
+								   8       1 test_sda1 433 0 0 38 10 10 10 5 5 40 49
+								   8       2 test_sda2 335 2265 2605 21 1 1 1 1 1 21 21
+								   8       3 test_sda3 325 1 2621 30 1 1 1 1 1 35 35
+								   8       4 test_sda4 327 8 2667 26 2 2 2 2 2 66 67
+								   8      16 test_sdb 197892 10232 6405354 76685 11645881 15066577 592065256 7906803 0 1237805 7973811
+								   8      17 test_sdb1 79194 994 3301796 23665 8288070 13802818 533998915 6032426 6 1162287 6047378
+								   8      18 test_sdb2 118690 9912 3101860 53256 29710061 1262766 58036346 1859478 4 106881 1918868`)
+
+	// 	mocked content of srcMockFileOldVer (kernel < 2.6)
+	srcMockFileOldVerCont := []byte(`   8       0 test_sda 1546 12644 0 0 	
+								   8       1 test_sda1 333 2728 0 0								
+								   8       2 test_sda2 330 2604 0 0								
+								   8       3 test_sda3 328 2624 0 0								
+								   8       4 test_sda4 325 2600 0 0								
+								   8      16 test_sdb 197890 6405324 11345881 592035256								
+								   8      17 test_sdb1 79104 3301786 8288060  533998912								
+								   8      18 test_sdb2 118610 3101850 2979961 58036344`)
+
+	f, _ := os.Create(srcMockFile)
+	f.Write(srcMockFileCont)
+
+	f, _ = os.Create(srcMockFileNext)
+	f.Write(srcMockFileNextCont)
+
+	f, _ = os.Create(srcMockFileOldVer)
+	f.Write(srcMockFileOldVerCont)
+}
+
+func createInvalidMockFile(kind int) {
+	os.Remove(srcMockFileInv)
+
+	var srcMockFileContInv []byte
+
+	switch kind {
+	case invalidValue:
+		srcMockFileContInv = []byte(`    8       0 test_sda 0 100 ccc 200`)
+		break
+
+	case invalidEntry:
+		srcMockFileContInv = []byte(`    1       2 unknown entry`)
+		break
+
+	case invalidMinor:
+		srcMockFileContInv = []byte(`    1       A test_sda 0 100 200 300`)
+		break
+
+	default:
+		srcMockFileContInv = []byte(``)
+		break
+
+	}
+
+	f, _ := os.Create(srcMockFileInv)
+	f.Write(srcMockFileContInv)
+
+}
+
+func deleteMockFiles() {
+	os.Remove(srcMockFile)
+	os.Remove(srcMockFileOldVer)
+	os.Remove(srcMockFileInv)
+	os.Remove(srcMockFileNext)
+}

--- a/examples/tasks/diskstats-file.json
+++ b/examples/tasks/diskstats-file.json
@@ -1,0 +1,80 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/linux/disk/sda/ops_read": {},
+                "/intel/linux/disk/sda/ops_write": {},
+                "/intel/linux/disk/sda/merged_read": {},
+                "/intel/linux/disk/sda/merged_write": {},
+                "/intel/linux/disk/sda/octets_read": {},
+                "/intel/linux/disk/sda/octets_write": {},
+                "/intel/linux/disk/sda/io_time": {},
+                "/intel/linux/disk/sda/time_read": {},
+                "/intel/linux/disk/sda/time_write": {},
+                "/intel/linux/disk/sda/weighted_io_time": {},
+                "/intel/linux/disk/sda/pending_ops": {},
+                "/intel/linux/disk/sda1/ops_read": {},
+                "/intel/linux/disk/sda1/ops_write": {},
+                "/intel/linux/disk/sda1/merged_read": {},
+                "/intel/linux/disk/sda1/merged_write": {},
+                "/intel/linux/disk/sda1/octets_read": {},
+                "/intel/linux/disk/sda1/octets_write": {},
+                "/intel/linux/disk/sda1/io_time": {},
+                "/intel/linux/disk/sda1/time_read": {},
+                "/intel/linux/disk/sda1/time_write": {},
+                "/intel/linux/disk/sda1/weighted_io_time": {},
+                "/intel/linux/disk/sda1/pending_ops": {},
+                "/intel/linux/disk/sdb/ops_read": {},
+                "/intel/linux/disk/sdb/ops_write": {},
+                "/intel/linux/disk/sdb/merged_read": {},
+                "/intel/linux/disk/sdb/merged_write": {},
+                "/intel/linux/disk/sdb/octets_read": {},
+                "/intel/linux/disk/sdb/octets_write": {},
+                "/intel/linux/disk/sdb/io_time": {},
+                "/intel/linux/disk/sdb/time_read": {},
+                "/intel/linux/disk/sdb/time_write": {},
+                "/intel/linux/disk/sdb/weighted_io_time": {},
+                "/intel/linux/disk/sdb/pending_ops": {},
+                "/intel/linux/disk/sdb1/ops_read": {},
+                "/intel/linux/disk/sdb1/ops_write": {},
+                "/intel/linux/disk/sdb1/merged_read": {},
+                "/intel/linux/disk/sdb1/merged_write": {},
+                "/intel/linux/disk/sdb1/octets_read": {},
+                "/intel/linux/disk/sdb1/octets_write": {},
+                "/intel/linux/disk/sdb1/io_time": {},
+                "/intel/linux/disk/sdb1/time_read": {},
+                "/intel/linux/disk/sdb1/time_write": {},
+                "/intel/linux/disk/sdb1/weighted_io_time": {},
+                "/intel/linux/disk/sdb1/pending_ops": {},
+                "/intel/linux/disk/sdb2/ops_read": {},
+                "/intel/linux/disk/sdb2/ops_write": {},
+                "/intel/linux/disk/sdb2/merged_read": {},
+                "/intel/linux/disk/sdb2/merged_write": {},
+                "/intel/linux/disk/sdb2/octets_read": {},
+                "/intel/linux/disk/sdb2/octets_write": {},
+                "/intel/linux/disk/sdb2/io_time": {},
+                "/intel/linux/disk/sdb2/time_read": {},
+                "/intel/linux/disk/sdb2/time_write": {},
+                "/intel/linux/disk/sdb2/weighted_io_time": {},
+                "/intel/linux/disk/sdb2/pending_ops": {}
+            },
+            "config": {
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "plugin_version": 3,
+                    "config": {
+                        "file": "/tmp/published_diskstats"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,40 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2015 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the snap plugin library
+	"github.com/intelsdi-x/snap/control/plugin"
+
+	// Import our collector plugin implementation
+	"github.com/intelsdi-x/snap-plugin-collector-disk/disk"
+)
+
+func main() {
+
+	p, err := disk.New()
+	if err != nil {
+		panic(err)
+	}
+	plugin.Start(
+		plugin.NewPluginMeta(disk.Name, disk.Version, disk.Type, []string{}, []string{plugin.SnapGOBContentType}, plugin.ConcurrencyCount(1)),
+		p,
+		os.Args[1],
+	)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go disk/"
+	VET_DIRS=". ./iostat/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+
+	go tool cover -func profile.cov
+
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
This plugin has ability to gather disk statistics such as:

| Namespace | Description |
| --- | --- |
| merged_read | The number of read operations per second that could be merged with already queued operations. |
| merged_write | The number of write operations per second that could be merged with already queued operations. |
| octets_read | The number of octets (bytes) read per second. |
| octets_write | The number of octets (bytes) written per second. |
| ops_read | The number of read operations per second. |
| ops_write | The number of write operations per second. |
| time_read | The average time for a read operation to complete in the last interval. |
| time_write | the average time for a write operation to complete in the last interval. |

Metric namespace prefix is `/intel/linux/disk/<disk_device>/` 

**Sample output from `snapctl task watch`:**
![image](https://cloud.githubusercontent.com/assets/11335874/12020936/c9df8628-ad81-11e5-919b-d301d80a57a8.png)
