### PR TITLE
Added conversion to float for metric output

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -217,7 +217,9 @@ func (dc *DiskCollector) CollectMetrics(mts []plugin.MetricType) ([]plugin.Metri
 						ns1[len(ns1)-2].Name = ns[len(ns)-2].Name
 						metric := plugin.MetricType{
 							Namespace_: ns1,
-							Data_:      dc.data.stats[i],
+							//This is because the first time data is collected, it is stored as a uint64 when parsing
+							//However, the type difference can cause issues with some databases (like InfluxDB)
+							Data_:      float64(dc.data.stats[i]),
 							Timestamp_: dc.data.timestamp,
 						}
 						metrics = append(metrics, metric)


### PR DESCRIPTION
This fixes a bug that was found in [this issue](https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/issues/67). The first collection of data was returning `uint64` instead of `float64` and this caused issues with Influx DB thinking they were different types.

cc @intelsdi-x/plugin-maintainers 