### PR TITLE
Fixed #22: do not send the first derivatives value

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,19 @@ This plugin has the ability to gather the following metrics:
 
 Metric namespace is `/intel/procfs/disk/<disk_device>/<metric_name>` where `<disk_device>` expands to sda, sda1, sdb, sdb1 and so on.
 
-Metric namespace | Description
------------- | -------------
-/intel/procfs/disk/\<disk_device\>/merged_read | The number of read operations per second that could be merged with already queued operations.
-/intel/procfs/disk/\<disk_device\>/merged_write | The number of write operations per second that could be merged with already queued operations.
-/intel/procfs/disk/\<disk_device\>/octets_read | The number of octets (bytes) read per second.
-/intel/procfs/disk/\<disk_device\>/octets_write | The number of octets (bytes) written per second.
-/intel/procfs/disk/\<disk_device\>/ops_read | The number of read operations per second.
-/intel/procfs/disk/\<disk_device\>/ops_write | The number of write operations per second.
-/intel/procfs/disk/\<disk_device\>/time_read | The average time for a read operation to complete in the last interval, in miliseconds.
-/intel/procfs/disk/\<disk_device\>/time_write | The average time for a write operation to complete in the last interval, in miliseconds.
-/intel/procfs/disk/\<disk_device\>/io_time | The time spent doing I/Os, in miliseconds.
-/intel/procfs/disk/\<disk_device\>/weighted_io_time<sup>(1)</sup> | The weighted time spent doing I/Os, in miliseconds.
+Metric namespace | Type | Description
+------------ | ------------- | -------------
+/intel/procfs/disk/\<disk_device\>/merged_read | derive | The number of read operations per second that could be merged with already queued operations.
+/intel/procfs/disk/\<disk_device\>/merged_write | derive | The number of write operations per second that could be merged with already queued operations.
+/intel/procfs/disk/\<disk_device\>/octets_read |derive |  The number of octets (bytes) read per second.
+/intel/procfs/disk/\<disk_device\>/octets_write | derive | The number of octets (bytes) written per second.
+/intel/procfs/disk/\<disk_device\>/ops_read | derive | The number of read operations per second.
+/intel/procfs/disk/\<disk_device\>/ops_write | derive | The number of write operations per second.
+/intel/procfs/disk/\<disk_device\>/time_read | derive |  The average time for a read operation to complete in the last interval, in miliseconds.
+/intel/procfs/disk/\<disk_device\>/time_write | derive |  The average time for a write operation to complete in the last interval, in miliseconds.
+/intel/procfs/disk/\<disk_device\>/io_time | derive | The time spent doing I/Os, in miliseconds.
+/intel/procfs/disk/\<disk_device\>/weighted_io_time<sup>(1)</sup> | derive | The weighted time spent doing I/Os, in miliseconds.
+/intel/procfs/disk/\<disk_device\>/pending_ops</sup> | gauge | The queue size of pending I/O operation.
 
 <sup>1)</sup> The value of metric `weighted_io_time` is incremented at each I/O start, I/O completion, I/O merge, or read of these stats by the number of I/Os in progress times the number of milliseconds spent doing I/O since the
 last update of this field.

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: dca2cf749a7496a7fc9b476a5e8fe75a6b74ef65c7b2b6e880f31ec9a1d8a428
-updated: 2016-10-27T14:11:10.759279255-07:00
+hash: 577285134234fb7d485bf38cc91e6a3fe9efaa3030f79c1442189417c3a51a5a
+updated: 2016-11-02T20:04:18.415316327+01:00
 imports:
 - name: github.com/intelsdi-x/snap
-  version: 891c09fd7e93aaf7cc0fb976fb91407901fd3843
+  version: c14d5c2330ec39da8d502da1856bef6acd4c6b30
   subpackages:
   - control/plugin
   - control/plugin/cpolicy
@@ -14,17 +14,18 @@ imports:
   - core/serror
   - pkg/ctree
   - pkg/schedule
+  - pkg/stringutils
   - scheduler/wmap
 - name: github.com/intelsdi-x/snap-plugin-utilities
-  version: f907c27a012b4e57329799c1f00fb22241243f2d
+  version: 925bafffac36edcfaf4aff937dcb7d3d5659782d
   subpackages:
   - config
 - name: github.com/robfig/cron
-  version: 0f39cf7ebc65a602f45692f9894bd6a193faf8fa
+  version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/Sirupsen/logrus
-  version: cd7d1bbe41066b6c1f19780f895901052150a575
+  version: be52937128b38f1d99787bb476c789e2af1147f1
 - name: golang.org/x/sys
-  version: c8bc69bc2db9c57ccf979550bc69655df5039a8a
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: gopkg.in/yaml.v2
@@ -42,7 +43,7 @@ testImports:
   - internal/go-render/render
   - internal/oglematchers
 - name: github.com/smartystreets/goconvey
-  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
+  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
   subpackages:
   - convey
   - convey/gotest

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,7 @@
-package: github.com/intelsdi-x/snap-plugin-collector-disk
-import:
-- package: github.com/Sirupsen/logrus
-  version: cd7d1bbe41066b6c1f19780f895901052150a575
-- package: github.com/intelsdi-x/snap-plugin-utilities
-  version: f907c27a012b4e57329799c1f00fb22241243f2d
-  subpackages:
-  - config
-- package: github.com/intelsdi-x/snap
+hash: dca2cf749a7496a7fc9b476a5e8fe75a6b74ef65c7b2b6e880f31ec9a1d8a428
+updated: 2016-10-27T14:11:10.759279255-07:00
+imports:
+- name: github.com/intelsdi-x/snap
   version: 891c09fd7e93aaf7cc0fb976fb91407901fd3843
   subpackages:
   - control/plugin
@@ -20,16 +15,35 @@ import:
   - pkg/ctree
   - pkg/schedule
   - scheduler/wmap
-- package: github.com/robfig/cron
+- name: github.com/intelsdi-x/snap-plugin-utilities
+  version: f907c27a012b4e57329799c1f00fb22241243f2d
+  subpackages:
+  - config
+- name: github.com/robfig/cron
   version: 0f39cf7ebc65a602f45692f9894bd6a193faf8fa
-- package: golang.org/x/sys
+- name: github.com/Sirupsen/logrus
+  version: cd7d1bbe41066b6c1f19780f895901052150a575
+- name: golang.org/x/sys
   version: c8bc69bc2db9c57ccf979550bc69655df5039a8a
   subpackages:
   - unix
-- package: gopkg.in/yaml.v2
+- name: gopkg.in/yaml.v2
   version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
-testImport:
-- package: github.com/smartystreets/goconvey
-  version: ^1.6.2
+testImports:
+- name: github.com/gopherjs/gopherjs
+  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
+  subpackages:
+  - js
+- name: github.com/jtolds/gls
+  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
+- name: github.com/smartystreets/assertions
+  version: 443d812296a84445c202c085f19e18fc238f8250
+  subpackages:
+  - internal/go-render/render
+  - internal/oglematchers
+- name: github.com/smartystreets/goconvey
+  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
   subpackages:
   - convey
+  - convey/gotest
+  - convey/reporting


### PR DESCRIPTION
Fixes #22

Summary of changes:
- do not send the first derived values
- handle dynamic metrics in "CollectMetrics" in the model way
- added "calcGauge()" to set an value of `pending_ops` metric in separate place (before it was done in "calcDerivatives()" and do not skip this gauge-type metric in the first collection
- updated README.md:
  - added info about type of metric
  - added missing `pending_ops` metric to the metric list

How to verify it:
- run exemplary task manifest: in the first collection only gauge metric (_pending_ops_) is returned, the derived metrics are available from the second collection as expected

Testing done:
- legacy test
- run exemplary task manifest to verify that the first values of derive metrics are consistent
