### PR TITLE
Snap binaries changed to snaptel/snapteld

### DIFF
--- a/examples/tasks/mock-disk.sh
+++ b/examples/tasks/mock-disk.sh
@@ -20,30 +20,30 @@ _info "Get latest plugins"
 
 SNAP_FLAG=0
 
-# this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
+# this block will wait check if snaptel and snapteld are loaded before the plugins are loaded and the task is started
  for i in `seq 1 5`; do
-             if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
+             if [[ -f /usr/local/bin/snaptel && -f /usr/local/sbin/snapteld ]];
                 then
 
                     _info "loading plugins"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-disk"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-collector-disk"
 
                     _info "creating and starting a task"
-                    snapctl task create -t "${__dir}/task-mock-disk.yml" 
+                    snaptel task create -t "${__dir}/task-mock-disk.yml"
 
                     SNAP_FLAG=1
 
                     break
              fi 
         
-        _info "snapctl and/or snapd are unavailable, sleeping for 3 seconds" 
+        _info "snaptel and/or snapteld are unavailable, sleeping for 3 seconds"
         sleep 3
 done 
 
 
-# check if snapctl/snapd have loaded
+# check if snaptel/snapteld have loaded
 if [ $SNAP_FLAG -eq 0 ]
     then
-     echo "Could not load snapctl or snapd"
+     echo "Could not load snaptel or snapteld"
      exit 1
 fi

--- a/examples/tasks/run-mock-disk.sh
+++ b/examples/tasks/run-mock-disk.sh
@@ -18,4 +18,4 @@ export PLUGIN_SRC="${__proj_dir}"
 . "${__proj_dir}/examples/tasks/.setup.sh"
 
 # downloads plugins, starts snap, load plugins and start a task
-cd "${__proj_dir}/examples/tasks" && docker-compose exec main bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-disk.sh && printf \"\n\nhint: type 'snapctl task list'\ntype 'exit' when your done\n\n\" && bash"
+cd "${__proj_dir}/examples/tasks" && docker-compose exec main bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-disk.sh && printf \"\n\nhint: type 'snaptel task list'\ntype 'exit' when your done\n\n\" && bash"

--- a/scripts/large_tests.sh
+++ b/scripts/large_tests.sh
@@ -19,7 +19,7 @@ sleep 10
 # begin assertions
 return_code=0
 echo -n "[task is running] "
-task_list=$(snapctl task list | tail -1)
+task_list=$(snaptel task list | tail -1)
 if echo $task_list | grep -q Running; then
     echo "ok"
 else 


### PR DESCRIPTION
Changed Snap binaries to snaptel/snapteld

Summary of changes:
- changes snapd to snapteld in example and in large tests
- changes snapctl to snaptel in example and in large tests
