### PR TITLE
Added exemplary task manifest with specified disk

### DIFF
--- a/examples/tasks/disk_all-file_influxdb.json
+++ b/examples/tasks/disk_all-file_influxdb.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/disk/*": {}
+      },
+      "config": {
+        "/intel/procfs/disk": {
+          "proc_path": "/proc"
+        }
+      },
+      "process": null,
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_diskstats_all.log"
+          }
+        },
+        {
+          "plugin_name": "influxdb",
+          "config": {
+            "host": "127.0.0.1",
+            "port": 8086,
+            "database": "snap",
+            "user": "admin",
+            "password": "admin"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/tasks/disk_sda-file.json
+++ b/examples/tasks/disk_sda-file.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/disk/sda/*": {}
+      },
+      "config": {
+        "/intel/procfs/disk": {
+          "proc_path": "/proc"
+        }
+      },
+      "process": null,
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_diskstats_sda.log"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/tasks/disk_sdb-file.json
+++ b/examples/tasks/disk_sdb-file.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/disk/sdb/ops_read": {},
+        "/intel/procfs/disk/sdb/ops_write": {},
+        "/intel/procfs/disk/sdb/merged_read": {},
+        "/intel/procfs/disk/sdb/merged_write": {},
+        "/intel/procfs/disk/sdb/octets_read": {},
+        "/intel/procfs/disk/sdb/octets_write": {},
+        "/intel/procfs/disk/sdb/io_time": {},
+        "/intel/procfs/disk/sdb/time_read": {},
+        "/intel/procfs/disk/sdb/time_write": {},
+        "/intel/procfs/disk/sdb/weighted_io_time": {},
+        "/intel/procfs/disk/sdb/pending_ops": {}
+      },
+      "config": {
+        "/intel/procfs/disk": {
+          "proc_path": "/proc"
+        }
+      },
+      "process": null,
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_diskstats_sdb.log"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/intelsdi-x/snap-plugin-collector-disk/issues/12

## Summary of changes:
- added exemplary task manifest to show how to request metrics per-disk 

## How to verify it:
- run exemplary task manifest with specified interface (e.g. `disk_sda-file.json` or `disk_sdb-file.json`)

### Example:
1. load snap-plugin-collector-disk:
```
snaptel plugin load snaptel plugin load ./build/linux/x86_64/snap-plugin-collector-disk
```

2. create task manifest with a specified dynamic element (disk), see examples/tasks/:
```

  "version": 1,
  "schedule": {
    "type": "simple",
    "interval": "1s"
  },
  "workflow": {
    "collect": {
      "metrics": {
        "/intel/procfs/disk/sda/*": {}
      },
      "config": {
        "/intel/procfs/disk": {
          "proc_path": "/proc"
        }
      },
      "process": null,
      "publish": [
        {
          "plugin_name": "file",
          "config": {
            "file": "/tmp/published_diskstats_sda.log"
          }
        }
      ]
    }
  }
}
```

3. load a declared publisher:  snap-plugin-publisher-file:
```
snaptel plugin load snaptel plugin load <path-to-snap-plugin-publisher-file>
```

4. create a task:
```
$ snaptel task create -t  examples/tasks/disk_sda-file.json

Using task manifest to create task
Task created
ID: 72166b3e-4236-46ef-89f1-a9088441f113
Name: Task-72166b3e-4236-46ef-89f1-a9088441f113
State: Running
```

5. watch collected metrics:
(notice, that they come only from specified disk `sda`)
```
$ snaptel task watch  72166b3e-4236-46ef-89f1-a9088441f113

NAMESPACE                                        DATA                    TIMESTAMP
/intel/procfs/disk/sda/io_time                   0                       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/merged_read               0                       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/merged_write              7.982935636867953       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/octets_read               0                       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/octets_write              57221.68264506949       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/ops_read                  0                       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/ops_write                 7.982935636867953       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/pending_ops               0                       2016-12-05 12:44:17.94398502 +0100 CET
/intel/procfs/disk/sda/weighted_io_time          0                       2016-12-05 12:44:17.94398502 +0100 CET
```

