### PR TITLE
Fix typo in a link with releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin gather disk statistics from /proc/diskstats (Linux 2.6+) or /proc/pa
 
 #### Download the plugin binary:
 
-You can get the pre-built binaries for your OS and architecture from the plugin's [GitHub Releases](https://github.com/intelsdi-x/snap-plugin-collector-disk/releasess) page. Download the plugin from the latest release and load it into `snapteld` (`/opt/snap/plugins` is the default location for snap packages).
+You can get the pre-built binaries for your OS and architecture from the plugin's [GitHub Releases](https://github.com/intelsdi-x/snap-plugin-collector-disk/releases) page. Download the plugin from the latest release and load it into `snapteld` (`/opt/snap/plugins` is the default location for snap packages).
 
 #### To build the plugin binary:
 


### PR DESCRIPTION
Trivial fix.

Current link is invalid.
