### PR TITLE
Add config params to be able to ignore loopback and RAM devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This plugin gather disk statistics from /proc/diskstats (Linux 2.6+) or /proc/pa
 
 ## Table of Contents
 1. [Getting Started](#getting-started)
-  * [System Requirements](#system-requirements)
-  * [Installation](#installation)
-  * [Configuration and Usage](#configuration-and-usage)
+   * [System Requirements](#system-requirements)
+   * [Installation](#installation)
+   * [Configuration and Usage](#configuration-and-usage)
 2. [Documentation](#documentation)
-  * [Collected Metrics](#collected-metrics)
-  * [Examples](#examples)
-  * [Roadmap](#roadmap)
+   * [Collected Metrics](#collected-metrics)
+   * [Examples](#examples)
+   * [Roadmap](#roadmap)
 3. [Community Support](#community-support)
 4. [Contributing](#contributing)
 5. [License](#license)
@@ -53,6 +53,11 @@ This builds the plugin in `./build/`
 Configuration parameters:
 
 - `proc_path`: path to 'diskstats' or 'partitions' file (default: `/proc`)
+- `ignore_ram`: set to `true` to ignore RAM devices (default: false)
+- `ignore_loopback`: set to `true` to ignore loopback devices (default: false)
+
+By default metrics for all devices listed in `diskstats` file are reported. You can limit them by setting `ignore_ram` and/or `ignore_loopback` to true. Then devices with major number equals respectively 1 and/or 7 will be
+ignored in data collection.
 
 ## Documentation
 

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -67,6 +67,12 @@ var (
 		},
 	}
 
+	mockMtOpsRead = []plugin.Metric{
+		plugin.Metric{
+			Namespace: plugin.NewNamespace("intel", "procfs", "disk", "*", "ops_read"),
+		},
+	}
+
 	srcMockFile           = "/tmp/diskstats_mock"
 	srcMockFileNext       = "/tmp/diskstats_mock_next"
 	srcMockFileOldVer     = "/tmp/partitions_mock"
@@ -231,6 +237,81 @@ func TestCollectMetrics(t *testing.T) {
 		})
 	})
 
+	Convey("Collect metrics wihout RAM and loopback devices", t, func() {
+		// mock requested metric
+		mockMtOpsRead := plugin.Metric{
+			Namespace: plugin.NewNamespace("intel", "procfs", "disk", "*", "ops_read"),
+			Config: plugin.Config{
+				"ignore_loopback": true,
+				"ignore_ram":      true,
+			},
+		}
+
+		diskPlugin, err := New()
+		Convey("new disk collector", func() {
+			So(err, ShouldBeNil)
+		})
+
+		results, err := diskPlugin.CollectMetrics([]plugin.Metric{mockMtOpsRead})
+		Convey("first data collecting", func() {
+			So(err, ShouldBeNil)
+			So(results, ShouldBeEmpty)
+		})
+		Convey("next data collecting", func() {
+			Convey("ignore loopback and RAM devices", func() {
+				mockMtOpsRead.Config = plugin.Config{
+					"ignore_loopback": true,
+					"ignore_ram":      true,
+				}
+				results, err := diskPlugin.CollectMetrics([]plugin.Metric{mockMtOpsRead})
+				So(err, ShouldBeNil)
+
+				for _, r := range results {
+					So(r.Namespace.String(), ShouldNotResemble, "test_loop0")
+					So(r.Namespace.String(), ShouldNotResemble, "test_ram0")
+				}
+				So(len(results), ShouldEqual, 8)
+			})
+			Convey("ignore only loopback devices", func() {
+				mockMtOpsRead.Config = plugin.Config{
+					"ignore_loopback": true,
+					"ignore_ram":      false,
+				}
+				results, err := diskPlugin.CollectMetrics([]plugin.Metric{mockMtOpsRead})
+				So(err, ShouldBeNil)
+				So(len(results), ShouldEqual, 9)
+
+				for _, r := range results {
+					So(r.Namespace.String(), ShouldNotResemble, "test_loop0")
+				}
+			})
+			Convey("ignore only RAM devices", func() {
+				mockMtOpsRead.Config = plugin.Config{
+					"ignore_loopback": false,
+					"ignore_ram":      true,
+				}
+				results, err := diskPlugin.CollectMetrics([]plugin.Metric{mockMtOpsRead})
+				So(err, ShouldBeNil)
+				So(len(results), ShouldEqual, 9)
+
+				for _, r := range results {
+					So(r.Namespace.String(), ShouldNotResemble, "test_ram0")
+				}
+			})
+			Convey("do not ignore any devices", func() {
+				mockMtOpsRead.Config = plugin.Config{
+					"ignore_loopback": false,
+					"ignore_ram":      false,
+				}
+				results, err := diskPlugin.CollectMetrics([]plugin.Metric{mockMtOpsRead})
+				So(err, ShouldBeNil)
+				// ops_read metric for all listed devices should be returned,
+				// including `test_ram0` and `test_loop0`
+				So(len(results), ShouldEqual, 10)
+			})
+		})
+	})
+
 	Convey("invalid calculation of derivatives", t, func() {
 		diskPlugin, err := New()
 		Convey("new disk collector", func() {
@@ -264,34 +345,43 @@ func TestCollectMetrics(t *testing.T) {
 func createMockFiles() {
 	deleteMockFiles()
 	// 	mocked content of srcMockFile (kernel 2.6+)
-	srcMockFileCont := []byte(`    8       0 test_sda 1546 2303 12644 114 0 0 0 0 0 68 114
-								   8       1 test_sda1 333 8 2728 28 0 0 0 0 0 28 28
-								   8       2 test_sda2 330 2264 2604 20 0 0 0 0 0 20 20
-								   8       3 test_sda3 328 0 2624 29 0 0 0 0 0 29 29
-								   8       4 test_sda4 325 0 2600 25 0 0 0 0 0 25 25
-								   8      16 test_sdb 197890 10231 6405324 76885 11345881 15065577 592035256 7904803 0 1237705 7973111
-								   8      17 test_sdb1 79104 984 3301786 23605 8288060 13802816 533998912 6032422 0 1162267 6047374
-								   8      18 test_sdb2 118610 9212 3101850 53254 2979961 1262761 58036344 1859439 0 106811 1918865`)
+	srcMockFileCont := []byte(`
+	1       0 test_ram0 0 0 0 0 0 0 0 0 0 0 0
+   	7       0 test_loop0 0 0 0 0 0 0 0 0 0 0 0
+	8       0 test_sda 1546 2303 12644 114 0 0 0 0 0 68 114
+	8       1 test_sda1 333 8 2728 28 0 0 0 0 0 28 28
+	8       2 test_sda2 330 2264 2604 20 0 0 0 0 0 20 20
+	8       3 test_sda3 328 0 2624 29 0 0 0 0 0 29 29
+	8       4 test_sda4 325 0 2600 25 0 0 0 0 0 25 25
+	8      16 test_sdb 197890 10231 6405324 76885 11345881 15065577 592035256 7904803 0 1237705 7973111
+	8      17 test_sdb1 79104 984 3301786 23605 8288060 13802816 533998912 6032422 0 1162267 6047374
+	8      18 test_sdb2 118610 9212 3101850 53254 2979961 1262761 58036344 1859439 0 106811 1918865`)
 
 	// 	mocked content of srcMockFileNext (kernel 2.6+)	in next collection
-	srcMockFileNextCont := []byte(`8       0 test_sda 1541 2304 12645 115 1 1 1 1 1 69 115
-								   8       1 test_sda1 433 0 0 38 10 10 10 5 5 40 49
-								   8       2 test_sda2 335 2265 2605 21 1 1 1 1 1 21 21
-								   8       3 test_sda3 325 1 2621 30 1 1 1 1 1 35 35
-								   8       4 test_sda4 327 8 2667 26 2 2 2 2 2 66 67
-								   8      16 test_sdb 197892 10232 6405354 76685 11645881 15066577 592065256 7906803 0 1237805 7973811
-								   8      17 test_sdb1 79194 994 3301796 23665 8288070 13802818 533998915 6032426 6 1162287 6047378
-								   8      18 test_sdb2 118690 9912 3101860 53256 29710061 1262766 58036346 1859478 4 106881 1918868`)
+	srcMockFileNextCont := []byte(`
+	1       0 test_ram0 0 0 0 0 0 0 0 0 0 0 0
+	7       0 test_loop0 0 0 0 0 0 0 0 0 0 0 0
+	8       0 test_sda 1541 2304 12645 115 1 1 1 1 1 69 115
+	8       1 test_sda1 433 0 0 38 10 10 10 5 5 40 49
+	8       2 test_sda2 335 2265 2605 21 1 1 1 1 1 21 21
+	8       3 test_sda3 325 1 2621 30 1 1 1 1 1 35 35
+	8       4 test_sda4 327 8 2667 26 2 2 2 2 2 66 67
+	8      16 test_sdb 197892 10232 6405354 76685 11645881 15066577 592065256 7906803 0 1237805 7973811
+	8      17 test_sdb1 79194 994 3301796 23665 8288070 13802818 533998915 6032426 6 1162287 6047378
+	8      18 test_sdb2 118690 9912 3101860 53256 29710061 1262766 58036346 1859478 4 106881 1918868`)
 
 	// 	mocked content of srcMockFileOldVer (kernel < 2.6)
-	srcMockFileOldVerCont := []byte(`   8       0 test_sda 1546 12644 0 0 	
-								   8       1 test_sda1 333 2728 0 0								
-								   8       2 test_sda2 330 2604 0 0								
-								   8       3 test_sda3 328 2624 0 0								
-								   8       4 test_sda4 325 2600 0 0								
-								   8      16 test_sdb 197890 6405324 11345881 592035256								
-								   8      17 test_sdb1 79104 3301786 8288060  533998912								
-								   8      18 test_sdb2 118610 3101850 2979961 58036344`)
+	srcMockFileOldVerCont := []byte(`
+	 1       0 test_ram0 0 0 0 0
+	 7       0 test_loop0 0 0 0 0
+	 8       0 test_sda 1546 12644 0 0
+	 8       1 test_sda1 333 2728 0 0
+	 8       2 test_sda2 330 2604 0 0
+	 8       3 test_sda3 328 2624 0 0
+	 8       4 test_sda4 325 2600 0 0
+	 8      16 test_sdb 197890 6405324 11345881 592035256
+	 8      17 test_sdb1 79104 3301786 8288060  533998912
+	 8      18 test_sdb2 118610 3101850 2979961 58036344`)
 
 	f, _ := os.Create(srcMockFile)
 	f.Write(srcMockFileCont)

--- a/examples/tasks/disk_all-file_influxdb.json
+++ b/examples/tasks/disk_all-file_influxdb.json
@@ -11,7 +11,9 @@
       },
       "config": {
         "/intel/procfs/disk": {
-          "proc_path": "/proc"
+          "proc_path": "/proc",
+          "ignore_ram": false,
+          "ignore_loopback": false
         }
       },
       "process": null,

--- a/examples/tasks/diskstats-file.json
+++ b/examples/tasks/diskstats-file.json
@@ -21,7 +21,9 @@
       },
       "config": {
         "/intel/procfs/disk": {
-          "proc_path": "/var/procfs"
+          "proc_path": "/proc",
+          "ignore_ram": true,
+          "ignore_loopback": true
         }
       },
       "process": null,

--- a/examples/tasks/task-simple.yml
+++ b/examples/tasks/task-simple.yml
@@ -10,6 +10,5 @@
         /intel/procfs/disk/* : {}
       config:
         /intel/procfs/disk:
-            proc_path: "/proc"
             ignore_loopback: true
             ignore_ram: true


### PR DESCRIPTION
### Summary of changes:
- added config parameter `ignore_loopback` and `ignore_ram` 
- added small tests
- formatted tests
- updated exemplary files to show how to declare these parameters


### How to test it

a)  `ignore_loopback` and `ignore_ram` set to _false_ (default)
By default both  `ignore_loopback` and `ignore_ram` are set to _false_ , so the plugin works exactly as before (collecting metrics from all devices listed in /proc/diskstats) . 

For exemplary task manifest:

```
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  max-failures: 10
  workflow:
    collect:
      metrics:
        /intel/procfs/disk/*/io_time : {}
      config:
        /intel/procfs/disk:
            proc_path: "/proc"

```
Returned metrics include metrics for loop and ram devices:
```
/intel/procfs/disk/loop0/io_time                 0                       2017-10-10 09:15:44.448764792 +0000 UTC
/intel/procfs/disk/ram0/io_time                  0                       2017-10-10 09:16:20.453088115 +0000 UTC
/intel/procfs/disk/sda/io_time                   1.3330064672618316      2017-10-10 09:16:21.453571418 +0000 UTC
/intel/procfs/disk/sda1/io_time                  0                       2017-10-10 09:16:20.453088115 +0000 UTC
/intel/procfs/disk/sda2/io_time                  0                       2017-10-10 09:16:20.453088115 +0000 UTC
/intel/procfs/disk/sda3/io_time                  1.3331478533612604      2017-10-10 09:16:20.453088115 +0000 UTC
```

a)  `ignore_loopback` and `ignore_ram` set to _true_ 

For exemplary task manifest:
```
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  max-failures: 10
  workflow:
    collect:
      metrics:
        /intel/procfs/disk/* : {}
      config:
        /intel/procfs/disk:
            proc_path: "/proc"
            ignore_loopback: true
            ignore_ram: true

```

Returned metrics do NOT include metrics for loop and ram devices:
```
/intel/procfs/disk/sda/io_time                   1.3330064672618316      2017-10-10 09:16:21.453571418 +0000 UTC
/intel/procfs/disk/sda1/io_time                  0                       2017-10-10 09:16:20.453088115 +0000 UTC
/intel/procfs/disk/sda2/io_time                  0                       2017-10-10 09:16:20.453088115 +0000 UTC
/intel/procfs/disk/sda3/io_time                  1.3331478533612604      2017-10-10 09:16:20.453088115 +0000 UTC
```
